### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ N高情報サイトの公式リポジトリです。
 1. developブランチをforkします。
 2. forkしたリポジトリに変更を加えます。
 3. developブランチにPull Requestを贈ります。
-4. Margeされると[開発用サイト](https://h-high-school-media-develop.vercel.app/)に変更が反映されます。
-5. しばらくテストを行い、問題がなければmainブランチに[nnmykn](https://github.com/nnmykn)がMargeを行います。
+4. Mergeされると[開発用サイト](https://h-high-school-media-develop.vercel.app/)に変更が反映されます。
+5. しばらくテストを行い、問題がなければmainブランチに[nnmykn](https://github.com/nnmykn)がMergeを行います。
 
 ## Authors
 


### PR DESCRIPTION
Fix typo in README.md where "Merge" was replaced by "Marge".